### PR TITLE
Fix code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -14,6 +14,6 @@ router.get('/', limiter, getItems)
 router.post('/', addItem)
 
 // search in the list
-router.post('/search', search)
+router.post('/search', limiter, search)
 
 module.exports = router


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Node_JS_1/security/code-scanning/2](https://github.com/Brook-5686/Node_JS_1/security/code-scanning/2)

To fix the problem, we need to apply the rate limiter middleware to the `search` route handler. This will ensure that the number of requests to the `search` route is limited, preventing potential denial-of-service attacks.

- We will add the `limiter` middleware to the `search` route handler.
- This change will be made in the `routes/index.js` file.
- No additional methods, imports, or definitions are needed as the rate limiter is already defined and imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
